### PR TITLE
修复 window系统微信客户端 无法粘贴图片

### DIFF
--- a/src/utils/parseDataTransfer.ts
+++ b/src/utils/parseDataTransfer.ts
@@ -3,17 +3,14 @@ export default function parseDataTransfer(
   callback: (file: File) => void,
 ) {
   // const dataTransfer = e.dataTransfer || e.clipboardData;
-  const { items } = e.clipboardData;
-  if (items && items.length) {
+  const { files } = e.clipboardData;
+  if (files && files.length) {
     // eslint-disable-next-line no-plusplus
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i];
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
 
-      if (item.type.indexOf('image') !== -1) {
-        const file = item.getAsFile();
-        if (file) {
-          callback(file);
-        }
+      if (file && file.type.indexOf('image') !== -1) {
+        callback(file);
         e.preventDefault();
         break;
       }


### PR DESCRIPTION
window系统下微信客户端 clipboardData 的 items 不包含 files，这里只能直接提取 files 操作