### PR TITLE
Fix: miss key when use img in rightContent of nav

### DIFF
--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -24,7 +24,7 @@ export const Navbar = (props: NavbarProps) => {
       </div>
       <div className="Navbar-right">
         {rightContent.map((item) => (
-          <IconButton size="lg" {...item} key={item.icon} />
+          <IconButton size="lg" key={item.icon} {...item} />
         ))}
       </div>
     </header>


### PR DESCRIPTION
`key={item.icon}`,  there will be no icon when use img as a item.