### PR TITLE
触底滚动控制

### DIFF
--- a/src/components/Chat/index.tsx
+++ b/src/components/Chat/index.tsx
@@ -178,6 +178,7 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>((props, ref) => 
     rightAction,
     Composer = DComposer,
     isX,
+    nearBottomThreshold
   } = props;
   const [currentColorScheme, setCurrentColorScheme] = useState<'light' | 'dark'>('light');
 
@@ -252,6 +253,7 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>((props, ref) => 
           onScroll={onScroll}
           onBackBottomShow={onBackBottomShow}
           onBackBottomClick={onBackBottomClick}
+          nearBottomThreshold={nearBottomThreshold}
         />
         <div className="ChatFooter">
           {renderQuickReplies ? (

--- a/src/components/MessageContainer/index.tsx
+++ b/src/components/MessageContainer/index.tsx
@@ -19,6 +19,7 @@ export interface MessageContainerProps {
   renderBeforeMessageList?: () => React.ReactNode;
   onBackBottomShow?: () => void;
   onBackBottomClick?: () => void;
+  nearBottomThreshold?: number;
 }
 
 export interface MessageContainerHandle {
@@ -43,6 +44,7 @@ export const MessageContainer = React.forwardRef<MessageContainerHandle, Message
       renderMessageContent,
       onBackBottomShow,
       onBackBottomClick,
+      nearBottomThreshold = 2
     } = props;
 
     const [showBackBottom, setShowBackBottom] = useState(false);
@@ -126,7 +128,7 @@ export const MessageContainer = React.forwardRef<MessageContainerHandle, Message
       if (lastMessage.position === 'right') {
         // 自己发的消息，强制滚动到底部
         scrollToEnd({ force: true });
-      } else if (isNearBottom(wrapper, 2)) {
+      } else if (isNearBottom(wrapper, nearBottomThreshold)) {
         const animated = !!wrapper.scrollTop;
         scrollToEnd({ animated, force: true });
       } else {


### PR DESCRIPTION
流式传输使用updateMsg更新消息时在两个消息框高度内会强制滚动到最下方，若此时手动向上滚动浏览消息会出现冲突造成页面抖动
修改使用nearBottomThreshold参数使用户可以自定义范围触发滚动