### PR TITLE
Add Customizable LoadMore

### DIFF
--- a/demo/src/demo/PullToRefresh.tsx
+++ b/demo/src/demo/PullToRefresh.tsx
@@ -11,5 +11,35 @@ export default () => (
         </PullToRefresh>
       </div>
     </DemoSection>
+    
+    <DemoSection title="自定义加载更多区域">
+      <div style={{ height: '300px', padding: '12px', border: '1px solid #ccc' }}>
+        <PullToRefresh 
+          onRefresh={() => Promise.resolve({})}
+          loadMoreText={(onLoadMore) => (
+            <div 
+              style={{ 
+                display: 'flex', 
+                alignItems: 'center', 
+                justifyContent: 'center',
+                gap: '8px',
+                padding: '12px',
+                background: '#f5f5f5',
+                borderRadius: '8px',
+                margin: '8px',
+                cursor: 'pointer',
+                border: '1px solid #ddd',
+                transition: 'all 0.2s ease'
+              }}
+              onClick={onLoadMore}
+            >
+              <span>自定义加载更多区域</span>
+            </div>
+          )}
+        >
+          <div>list</div>
+        </PullToRefresh>
+      </div>
+    </DemoSection>
   </DemoPage>
 );

--- a/demo/src/demo/PullToRefresh.tsx
+++ b/demo/src/demo/PullToRefresh.tsx
@@ -19,17 +19,13 @@ export default () => (
           loadMoreText={(onLoadMore) => (
             <div 
               style={{ 
-                display: 'flex', 
-                alignItems: 'center', 
-                justifyContent: 'center',
-                gap: '8px',
+                width: '100%',
                 padding: '12px',
                 background: '#f5f5f5',
                 borderRadius: '8px',
                 margin: '8px',
                 cursor: 'pointer',
                 border: '1px solid #ddd',
-                transition: 'all 0.2s ease'
               }}
               onClick={onLoadMore}
             >

--- a/src/components/PullToRefresh/index.tsx
+++ b/src/components/PullToRefresh/index.tsx
@@ -249,16 +249,18 @@ export const PullToRefresh = React.forwardRef<PullToRefreshHandle, PullToRefresh
           >
             <div className="PullToRefresh-indicator">{renderIndicator(status, distance)}</div>
             {!disabled && useFallback && (
-              typeof loadMoreText === 'function' ? (
-                loadMoreText(handleLoadMore)
-              ) : (
-                <Flex className="PullToRefresh-fallback" center>
-                  {renderIndicator(status, oDistance)}
-                  <Button className="PullToRefresh-loadMore" variant="text" onClick={handleLoadMore}>
-                    {loadMoreText}
-                  </Button>
-                </Flex>
-              )
+              <Flex className="PullToRefresh-fallback" center>
+                {typeof loadMoreText === 'function' ? (
+                  loadMoreText(handleLoadMore)
+                ) : (
+                  <>
+                    {renderIndicator(status, oDistance)}
+                    <Button className="PullToRefresh-loadMore" variant="text" onClick={handleLoadMore}>
+                      {loadMoreText}
+                    </Button>
+                  </>
+                )}
+              </Flex>
             )}
             {React.Children.only(children)}
           </div>

--- a/src/components/PullToRefresh/index.tsx
+++ b/src/components/PullToRefresh/index.tsx
@@ -18,7 +18,7 @@ export interface PullToRefreshProps {
   distance?: number;
   loadingDistance?: number;
   distanceRatio?: number;
-  loadMoreText?: string;
+  loadMoreText?: string | ((onLoadMore: () => void) => React.ReactNode);
   maxDistance?: number;
   onRefresh?: () => Promise<any>;
   onScroll?: (event: React.UIEvent<HTMLDivElement, UIEvent>) => void;
@@ -249,12 +249,16 @@ export const PullToRefresh = React.forwardRef<PullToRefreshHandle, PullToRefresh
           >
             <div className="PullToRefresh-indicator">{renderIndicator(status, distance)}</div>
             {!disabled && useFallback && (
-              <Flex className="PullToRefresh-fallback" center>
-                {renderIndicator(status, oDistance)}
-                <Button className="PullToRefresh-loadMore" variant="text" onClick={handleLoadMore}>
-                  {loadMoreText}
-                </Button>
-              </Flex>
+              typeof loadMoreText === 'function' ? (
+                loadMoreText(handleLoadMore)
+              ) : (
+                <Flex className="PullToRefresh-fallback" center>
+                  {renderIndicator(status, oDistance)}
+                  <Button className="PullToRefresh-loadMore" variant="text" onClick={handleLoadMore}>
+                    {loadMoreText}
+                  </Button>
+                </Flex>
+              )
             )}
             {React.Children.only(children)}
           </div>


### PR DESCRIPTION
### 背景
在业务场景中需要对loadMore对样式进行自定义的改造，如图。

<img width="603" height="130" alt="Image" src="https://github.com/user-attachments/assets/ff52ead2-c988-4aed-8277-7a8620cc84f2" />

但是当前只支持更改loadMoreText，不支持对整体样式进行修改。  
如果用 renderBeforeMessageList 替代会有如下问题：  
- 需要重新手动实现点击/下拉刷新和滚动等一系列逻辑
- renderBeforeMessageList原本仅用于显示静态内容，这样会被用于非设计目的，职责混乱


### 更改
在loadMoreText增加传入(onLoadMore: () => void) => React.ReactNode的类型，可支持传入自定义的样式。